### PR TITLE
CA-119 Fixed Project.Name not editable bug.

### DIFF
--- a/src/CollAction/Data/ApplicationDbContext.cs
+++ b/src/CollAction/Data/ApplicationDbContext.cs
@@ -45,7 +45,7 @@ namespace CollAction.Data
             base.OnModelCreating(builder);
 
             builder.Entity<Tag>().HasAlternateKey(t => t.Name);
-            builder.Entity<Project>().HasAlternateKey(p => p.Name);
+            builder.Entity<Project>().HasIndex(p => p.Name).HasName("IX_Projects_Name").IsUnique();
             builder.Entity<Project>().Property(p => p.DisplayPriority).HasDefaultValue(ProjectDisplayPriority.Medium);
             builder.Entity<ProjectParticipant>().HasKey("UserId", "ProjectId");
             builder.Entity<ProjectTag>().HasKey("TagId", "ProjectId");

--- a/src/CollAction/Migrations/20170131095048_ProjectNameUniqueIndex.Designer.cs
+++ b/src/CollAction/Migrations/20170131095048_ProjectNameUniqueIndex.Designer.cs
@@ -8,9 +8,10 @@ using CollAction.Data;
 namespace CollAction.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20170131095048_ProjectNameUniqueIndex")]
+    partial class ProjectNameUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.0.1");

--- a/src/CollAction/Migrations/20170131095048_ProjectNameUniqueIndex.cs
+++ b/src/CollAction/Migrations/20170131095048_ProjectNameUniqueIndex.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace CollAction.Migrations
+{
+    public partial class ProjectNameUniqueIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_Projects_Name",
+                table: "Projects");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Projects_Name",
+                table: "Projects",
+                column: "Name",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Projects_Name",
+                table: "Projects");
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_Projects_Name",
+                table: "Projects",
+                column: "Name");
+        }
+    }
+}


### PR DESCRIPTION
Changed Project.Name from using an AlternateKey to using a UniqueIndex.