### PR TITLE
forbid visual studio from compiling the typescript files itself

### DIFF
--- a/CollAction/CollAction.csproj
+++ b/CollAction/CollAction.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix visual studio trying to build the typescript files with its new typescript integration.

In some future, we might want to use that integration, might be nice for development, for now, this is a quick fix.
