### PR TITLE
Fix the webpack on build

### DIFF
--- a/CollAction/CollAction.csproj
+++ b/CollAction/CollAction.csproj
@@ -7,7 +7,7 @@
     <DisableImplicitFrameworkReference>true</DisableImplicitFrameworkReference>  
     <UserSecretsId>aspnet-CollAction-29a5d7b8-3530-4482-9ed6-572bd6c178fa</UserSecretsId>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
-    <PreBuildEvent>npm install
+    <PreBuildEvent>npm install &amp;&amp; ^
 npm run build</PreBuildEvent>
   </PropertyGroup>
 


### PR DESCRIPTION
Bit stupid, but aparently visual studio can't execute two pre-build event lines correctly without tricks.