### PR TITLE
CA-206-StartProjectTargetNumber:

### DIFF
--- a/CollAction/Models/AdminViewModels/ManageProjectViewModel.cs
+++ b/CollAction/Models/AdminViewModels/ManageProjectViewModel.cs
@@ -42,7 +42,8 @@ namespace CollAction.Models.AdminViewModels
         public int CategoryId { get; set; }
 
         [Required(ErrorMessage = "Please specify the target number of collaborators required for your project to be deemed a success")]
-        [Range(1, Double.MaxValue, ErrorMessage = "Please enter the target number of participants.")]
+        [DataType(DataType.Text)] // Force this to text rather than .Int to prevent browsers displaying spin buttons (up down arrows) by default.
+        [Range(1, 1000000, ErrorMessage = "You can choose up to a maximum of one million participants as your target number.")]
         public int Target { get; set; }
 
         [Required]

--- a/CollAction/Models/ProjectViewModels/CreateProjectViewModel.cs
+++ b/CollAction/Models/ProjectViewModels/CreateProjectViewModel.cs
@@ -54,7 +54,8 @@ namespace CollAction.Models
         public int? LocationId { get; set; }
 
         [Required(ErrorMessage = "Please specify the target number of collaborators required for your project to be deemed a success")]
-        [Range(1, Double.MaxValue, ErrorMessage = "Please enter the target number of participants.")]
+        [DataType(DataType.Text)] // Force this to text rather than .Int to prevent browsers displaying spin buttons (up down arrows) by default.
+        [Range(1, 1000000, ErrorMessage = "You can choose up to a maximum of one million participants as your target number.")]
         public int Target { get; set; }
 
         [Required]

--- a/CollAction/Models/ProjectViewModels/EditProjectViewModel.cs
+++ b/CollAction/Models/ProjectViewModels/EditProjectViewModel.cs
@@ -56,7 +56,8 @@ namespace CollAction.Models
         public int? LocationId { get; set; }
 
         [Required(ErrorMessage = "Please specify the target number of collaborators required for your project to be deemed a success")]
-        [Range(1, Double.MaxValue, ErrorMessage = "Please enter the target number of participants.")]
+        [DataType(DataType.Text)] // Force this to text rather than .Int to prevent browsers displaying spin buttons (up down arrows) by default.
+        [Range(1, 1000000, ErrorMessage = "You can choose up to a maximum of one million participants as your target number.")]
         public int Target { get; set; }
 
         [Required]


### PR DESCRIPTION
- Updated the Create/Edit/Manage-ProjectViewModels so that the 'Target' number of participants is restricted to the range 1-10^6
- Also prevented browsers from displaying the spin buttons (up down arrows) by default on this field