### PR TITLE
Log the request header and http base address as well so we can see wh…

### DIFF
--- a/CollAction/Helpers/MailChimpManager.cs
+++ b/CollAction/Helpers/MailChimpManager.cs
@@ -93,7 +93,10 @@ namespace CollAction.Helpers
                     if (response.StatusCode != HttpStatusCode.OK)
                     {
                         string errorResponse = await GetMailChimpErrorResponse(response);
-                        throw new Exception("Failed to add or update MailChimp list member. Status code: " + response.StatusCode + " -> \r" + errorResponse);
+                        string httpRequestHeader = client.DefaultRequestHeaders.ToString();
+                        string httpRequestBaseAddress = client.BaseAddress.ToString();
+                        string diagnostics = string.Format("{0}httpRequestHeader: {1}\rhttpRequestBaseAddress:{2}", errorResponse, httpRequestHeader, httpRequestBaseAddress);
+                        throw new Exception("Failed to add or update MailChimp list member. Status code: " + response.StatusCode + " -> \r" + diagnostics);
                     }
                 }
             }


### PR DESCRIPTION
…at data center and api key MailChimp is trying to send requests to.

N.B. This assumes that the thrown exception is never shown publicly to an end user (Otherwise the API key would be displayed!!!).
These extra diagnostics should be removed once MailChimp has been fixed.