### PR TITLE
Fix build for mac/linux (imagesharp fixes)

### DIFF
--- a/CollAction/CollAction.csproj
+++ b/CollAction/CollAction.csproj
@@ -22,7 +22,7 @@ npm run build</PreBuildEvent>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleEmail" Version="3.3.2" />
-    <PackageReference Include="ImageSharp" Version="1.0.0-alpha7-00031" />
+    <PackageReference Include="ImageSharp" Version="1.0.0-alpha9-00194" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.2" />

--- a/CollAction/Helpers/ImageFileManager.cs
+++ b/CollAction/Helpers/ImageFileManager.cs
@@ -152,7 +152,7 @@ namespace CollAction.Helpers
                 using (MemoryStream ms = new MemoryStream())
                 {
                     await input.CopyToAsync(ms);
-                    Image image = Image.Load(ms.ToArray());
+                    Image<Rgba32> image = Image.Load(ms.ToArray());
                     return new ImageFile
                     {
                         Name = filename,

--- a/CollAction/ValidationAttributes/MaxImageDimensionsAttribute.cs
+++ b/CollAction/ValidationAttributes/MaxImageDimensionsAttribute.cs
@@ -29,10 +29,8 @@ namespace CollAction.ValidationAttributes
                     imageStream.CopyTo(ms);
                     try
                     {
-                        using (Image image = Image.Load(ms.ToArray()))
-                        {
-                            return image.Width <= _maxWidth && image.Height <= _maxHeight;
-                        }
+                        Image<Rgba32> image = Image.Load(ms.ToArray());
+                        return image.Width <= _maxWidth && image.Height <= _maxHeight;
                     }
                     catch (NotSupportedException)
                     {


### PR DESCRIPTION
This fixes the build for people who had issues. Older versions of imagesharp were deleted from myget I think.

There's a new docker image (collactionacceptance) up on the testserver.