### PR TITLE
Prevent two XHR-requests when loading projects

### DIFF
--- a/CollAction/Frontend/app/project/FindProject.tsx
+++ b/CollAction/Frontend/app/project/FindProject.tsx
@@ -28,7 +28,6 @@ export default class FindProject extends React.Component<IFindProjectProps, IFin
   }
 
   componentDidMount() {
-    this.fetchProjects();
   }
 
   async fetchProjects(projectFilter: IProjectFilter = null) {


### PR DESCRIPTION
The first call loads all projects (without a filter), triggered on the componentDidMount event. 

The master branch sets the filter to 'Open' after initialization, which triggers the second call with a filter. Only this one is needed.

Note: the Friesland branch does _not_ have a filter (and therefor needs the componentDidMount event to load projects. So this change can't be merged with the Friesland-branch.

I am a bit in doubt here; is it worth the effort to refactor this into a component that works in both situations? Since the master branch will probably never need a filter-less version of this component, and the Friesland-branch won't need one with a filter... what do you guys think?