### PR TITLE
Trigger loading projects on component mount if the widget doesn't hav…

### DIFF
--- a/CollAction/Frontend/app/project/FindProject.tsx
+++ b/CollAction/Frontend/app/project/FindProject.tsx
@@ -28,6 +28,9 @@ export default class FindProject extends React.Component<IFindProjectProps, IFin
   }
 
   componentDidMount() {
+    if (this.props.controller === false) {
+      this.fetchProjects();
+    }
   }
 
   async fetchProjects(projectFilter: IProjectFilter = null) {


### PR DESCRIPTION
To fix the double XHR requests from CA-360, I removed the fetch projects trigger on component mounting. As a result, projects were not loaded anymore when there is no controller. Fixed it by only triggering project loading if the widget has no controller.