### PR TITLE
Combined fixes for CA-389 and CA-378

### DIFF
--- a/CollAction/Frontend/app/global/RichTextEditor.tsx
+++ b/CollAction/Frontend/app/global/RichTextEditor.tsx
@@ -13,8 +13,12 @@ interface ICollActionEditorState {
 }
 
 export default class RichTextEditor extends React.Component<ICollActionEditorProps, ICollActionEditorState> {
+
+  private HREF_REGEX = /href=\"(?!http:\/\/|https:\/\/)([^\"]*)(\")/ig;
+
   constructor() {
     super();
+
     this.state = {
       content: ""
     };
@@ -42,12 +46,25 @@ export default class RichTextEditor extends React.Component<ICollActionEditorPro
   }
 
   handleChange(value) {
+    value = this.fixLinks(value);
+
     this.setState({ content: value });
 
     const input = document.getElementById(this.props.formInputId) as HTMLInputElement;
     if (input) {
       input.value = this.state.content;
     }
+  }
+
+  private fixLinks(value: string): string {
+    let link;
+
+    while ((link = this.HREF_REGEX.exec(value)) !== null) {
+      let url = link[1];
+      value = value.replace(url, "http://" + url);
+    }
+
+    return value;
   }
 
   render() {

--- a/CollAction/Frontend/app/project/FindProject.tsx
+++ b/CollAction/Frontend/app/project/FindProject.tsx
@@ -28,6 +28,9 @@ export default class FindProject extends React.Component<IFindProjectProps, IFin
   }
 
   componentDidMount() {
+    if (this.props.controller === false) {
+      this.fetchProjects();
+    }
   }
 
   async fetchProjects(projectFilter: IProjectFilter = null) {


### PR DESCRIPTION
Combined two separate bugfixes in one pull request:
* In master, homepage now shows running projects again
* In master, the rich text editor now automatically prefixes urls without protocol with 'http://' (otherwise it will treat them like relative URLs)