### PR TITLE
Projects on homepage will be fetched in parts on scroll

### DIFF
--- a/CollAction/Controllers/ProjectsController.cs
+++ b/CollAction/Controllers/ProjectsController.cs
@@ -313,7 +313,7 @@ namespace CollAction.Controllers
         }
 
         [HttpGet]
-        public async Task<JsonResult> FindProjects(int? categoryId, int? statusId, int? limit)
+        public async Task<JsonResult> FindProjects(int? categoryId, int? statusId, int? limit, int start)
         {
             Expression<Func<Project, bool>> projectExpression = (p =>
                 p.Status != ProjectStatus.Hidden &&
@@ -329,7 +329,7 @@ namespace CollAction.Controllers
                 default: statusExpression = (p => true); break;
             }
 
-            var projects = await _projectService.FindProjects(Expression.Lambda<Func<Project, bool>>(Expression.AndAlso(projectExpression.Body, Expression.Invoke(statusExpression, projectExpression.Parameters[0])), projectExpression.Parameters[0]), limit).ToListAsync();
+            var projects = await _projectService.FindProjects(Expression.Lambda<Func<Project, bool>>(Expression.AndAlso(projectExpression.Body, Expression.Invoke(statusExpression, projectExpression.Parameters[0])), projectExpression.Parameters[0]), limit, start).ToListAsync();
 
             return Json(projects);
         }

--- a/CollAction/Frontend/app/account/MyProjects.tsx
+++ b/CollAction/Frontend/app/account/MyProjects.tsx
@@ -12,6 +12,7 @@ export default class MyProjects extends Projects<IProjectsProps, IProjectsState>
       projectList,
       projectFetching: false,
       projectFetchError: null,
+      allProjectsFetched: false
     };
   }
 

--- a/CollAction/Frontend/app/account/ParticipatingInProjects.tsx
+++ b/CollAction/Frontend/app/account/ParticipatingInProjects.tsx
@@ -12,6 +12,7 @@ export default class ParticipatingInProjects extends Projects<IProjectsProps, IP
       projectList,
       projectFetching: false,
       projectFetchError: null,
+      allProjectsFetched: false
     };
   }
 

--- a/CollAction/Frontend/app/global/Projects.tsx
+++ b/CollAction/Frontend/app/global/Projects.tsx
@@ -8,6 +8,7 @@ export interface IProjectsState {
   projectList: IProject[];
   projectFetching: boolean;
   projectFetchError: any;
+  allProjectsFetched: boolean;
 }
 
 export abstract class Projects<P extends IProjectsProps, S extends IProjectsState> extends React.Component<P, S> {
@@ -26,7 +27,7 @@ export abstract class Projects<P extends IProjectsProps, S extends IProjectsStat
 
             const fetchResult: Response = await fetch(searchProjectRequest);
             const jsonResponse = await fetchResult.json();
-            this.setState({ projectFetching: false, projectList: jsonResponse });
+            this.setState({ projectFetching: false, projectList: jsonResponse, allProjectsFetched: true });
         }
         catch (e) {
             this.setState({ projectFetching: false, projectFetchError: e });

--- a/CollAction/Frontend/app/project/FindProject.tsx
+++ b/CollAction/Frontend/app/project/FindProject.tsx
@@ -40,7 +40,6 @@ export default class FindProject extends Projects<IFindProjectProps, IFindProjec
   }
 
   componentDidMount() {
-
     if (this.props.controller === false) {
       this.fetchProjects();
     }
@@ -50,13 +49,11 @@ export default class FindProject extends Projects<IFindProjectProps, IFindProjec
   }
 
   componentWillUnmount() {
-
     // Unbind scroll event
     window.removeEventListener("scroll", this.onScroll, false);
   }
 
   onScroll = () => {
-
     let treshold = 200;
 
     // Check if window scrolled to half of project list
@@ -68,7 +65,6 @@ export default class FindProject extends Projects<IFindProjectProps, IFindProjec
   }
 
   async fetchProjects(projectFilter: IProjectFilter = null, start: number = 0) {
-
     // Prevent unnecessary fetching
     if (this.state.projectFetching || this.state.allProjectsFetched) {
       return;

--- a/CollAction/Frontend/app/project/FindProject.tsx
+++ b/CollAction/Frontend/app/project/FindProject.tsx
@@ -6,6 +6,7 @@ import renderComponentIf from "../global/renderComponentIf";
 
 interface IFindProjectProps extends IProjectsProps {
   controller: boolean;
+  projectListContainerElement?: any;
 }
 
 interface IFindProjectState extends IProjectsState {
@@ -13,6 +14,12 @@ interface IFindProjectState extends IProjectsState {
 }
 
 export default class FindProject extends Projects<IFindProjectProps, IFindProjectState> {
+
+  // Define project list DOM element reference for scrolling
+  private projectListContainerElement: React.RefObject<HTMLDivElement>;
+
+  // Define number of projects we want to fetch on scroll
+  private fetchNumberOfProjectsOnScroll;
 
   constructor (props) {
     super(props);
@@ -23,16 +30,50 @@ export default class FindProject extends Projects<IFindProjectProps, IFindProjec
       projectFilterState: null,
       projectFetching: false,
       projectFetchError: null,
+      allProjectsFetched: false
     };
+
+    // Set constants
+    this.projectListContainerElement = React.createRef();
+
+    this.fetchNumberOfProjectsOnScroll = 15;
   }
 
   componentDidMount() {
+
     if (this.props.controller === false) {
       this.fetchProjects();
     }
+
+    // Bind scroll event
+    window.addEventListener("scroll", this.onScroll, false);
   }
 
-  async fetchProjects(projectFilter: IProjectFilter = null) {
+  componentWillUnmount() {
+
+    // Unbind scroll event
+    window.removeEventListener("scroll", this.onScroll, false);
+  }
+
+  onScroll = () => {
+
+    let treshold = 200;
+
+    // Check if window scrolled to half of project list
+    if (window.pageYOffset + window.innerHeight >= (this.projectListContainerElement.current.offsetTop + this.projectListContainerElement.current.offsetHeight) - treshold) {
+
+      // Fetch more projects
+      this.fetchProjects(this.state.projectFilterState, this.state.projectList.length);
+    }
+  }
+
+  async fetchProjects(projectFilter: IProjectFilter = null, start: number = 0) {
+
+    // Prevent unnecessary fetching
+    if (this.state.projectFetching || this.state.allProjectsFetched) {
+      return;
+    }
+
     this.setState({ projectFetching: true });
 
     // Fetch projects with out filters set
@@ -40,14 +81,24 @@ export default class FindProject extends Projects<IFindProjectProps, IFindProjec
       if (projectFilter) {
         return `/api/projects/find?categoryId=${projectFilter.categoryId}&statusId=${projectFilter.statusId}`;
       }
-      return "/api/projects/find?limit=30";
+      return `/api/projects/find?start=${start}&limit=${start + this.fetchNumberOfProjectsOnScroll}`;
     };
 
     try {
       const searchProjectRequest: Request = new Request(getUrl());
       const fetchResult: Response = await fetch(searchProjectRequest);
       const jsonResponse = await fetchResult.json();
-      this.setState({ projectFetching: false, projectList: jsonResponse });
+
+      // Add projects to project list
+      this.setState((prevState) => ({
+        projectFetching: false,
+        projectList: [...prevState.projectList, ...jsonResponse]
+      }));
+
+      // We assume that if no or less than limit are returned, all projects have been fetched
+      if (!jsonResponse.length || jsonResponse.length < this.fetchNumberOfProjectsOnScroll) {
+        this.setState({ allProjectsFetched: true });
+      }
     }
     catch (e) {
       this.setState({ projectFetching: false, projectFetchError: e });
@@ -72,7 +123,7 @@ export default class FindProject extends Projects<IFindProjectProps, IFindProjec
     return (
       <div id="find-project">
         { this.props.controller ?  controller : null }
-        <div className="container">
+        <div className="container" ref={this.projectListContainerElement}>
           <ProjectList projectList={this.state.projectList} tileClassName="col-xs-12 col-md-4" />
         </div>
       </div>

--- a/CollAction/Services/Project/IProjectService.cs
+++ b/CollAction/Services/Project/IProjectService.cs
@@ -19,7 +19,7 @@ namespace CollAction.Services.Project
         bool CanSendProjectEmail(Models.Project project);
         Task SendProjectEmail(Models.Project project, string subject, string message, HttpRequest request, IUrlHelper helper);
         IQueryable<DisplayProjectViewModel> GetProjectDisplayViewModels(Expression<Func<Models.Project, bool>> filter);
-        IQueryable<FindProjectsViewModel> FindProjects(Expression<Func<Models.Project, bool>> filter, int? limit);
+        IQueryable<FindProjectsViewModel> FindProjects(Expression<Func<Models.Project, bool>> filter, int? limit, int? start);
         int NumberEmailsAllowedToSend(Models.Project project);
         DateTime CanSendEmailsUntil(Models.Project project);
         Task RefreshParticipantCountMaterializedView();

--- a/CollAction/Services/Project/ProjectService.cs
+++ b/CollAction/Services/Project/ProjectService.cs
@@ -84,7 +84,7 @@ namespace CollAction.Services.Project
             return await _context.ProjectParticipants.SingleOrDefaultAsync(p => p.ProjectId == projectId && p.UserId == userId);
         }
 
-        public IQueryable<FindProjectsViewModel> FindProjects(Expression<Func<Models.Project, bool>> filter, int? limit)
+        public IQueryable<FindProjectsViewModel> FindProjects(Expression<Func<Models.Project, bool>> filter, int? limit, int? start)
         {
             IQueryable<Models.Project> projects = _context.Projects
                 .Where(filter)
@@ -92,6 +92,9 @@ namespace CollAction.Services.Project
 
             if (limit.HasValue)
                 projects = projects.Take(limit.Value);
+
+            if(start.HasValue)
+                projects = projects.Skip(start.Value);
 
             return projects
                 .Select(project =>


### PR DESCRIPTION
I configured it so that every time you scroll until the bottom section of the project list (minus treshold), 15 extra projects will be loaded. When there are less or no projects returned, fetching will stop.