### PR TITLE
Upgrade of dotnet needs cookie options explicitely

### DIFF
--- a/CollAction/Frontend/app/global/CookieMessage.tsx
+++ b/CollAction/Frontend/app/global/CookieMessage.tsx
@@ -14,6 +14,8 @@ export default class CookieMessage extends React.Component<ICookieMessageProps, 
     constructor(props) {
         super(props);
         this.state = { showBanner: false };
+
+        this.accept = this.accept.bind(this);
     }
 
     componentDidMount() {

--- a/CollAction/Startup.cs
+++ b/CollAction/Startup.cs
@@ -28,6 +28,7 @@ using CollAction.Services.Newsletter;
 using CollAction.Services.Festival;
 using CollAction.Services.DataProtection;
 using CollAction.Services.Image;
+using Microsoft.AspNetCore.Http;
 
 namespace CollAction
 {
@@ -106,6 +107,12 @@ namespace CollAction
                 options.Password.RequireUppercase = false;
                 options.Password.RequireNonAlphanumeric = false;
                 options.Password.RequiredLength = 8;
+            });
+
+            services.Configure<CookiePolicyOptions>(options => 
+            {
+                options.CheckConsentNeeded = context => true;
+                options.MinimumSameSitePolicy = SameSiteMode.None;
             });
         }
 


### PR DESCRIPTION
Apparently the cookie policy service of dotnet needs its options explicitly set, otherwise it won't work. Also, React upgrade requires methods that use properties of its component bound properly. 