### PR TITLE
Fixed projects filter on Find Project page

### DIFF
--- a/CollAction/Controllers/ProjectsController.cs
+++ b/CollAction/Controllers/ProjectsController.cs
@@ -315,7 +315,7 @@ namespace CollAction.Controllers
         }
 
         [HttpGet]
-        public async Task<JsonResult> FindProjects(int? categoryId, int? statusId, int? limit, int start)
+        public async Task<JsonResult> FindProjects(int? categoryId, int? statusId, int? limit, int? start)
         {
             Expression<Func<Project, bool>> projectExpression = (p =>
                 p.Status != ProjectStatus.Hidden &&


### PR DESCRIPTION
The project filter used the same fetchProjects method for fetching (filtered) projects as the on scroll functionality I integrated. But the API call on filter change was unreachable in fetchProjects() because it returned on this.state.allProjectsFetched. That should only be in case of fetching on scroll, not on filtering.