### PR TITLE
CA-681 - Set project target input to integer instead of text

### DIFF
--- a/CollAction/Models/ProjectViewModels/CreateProjectViewModel.cs
+++ b/CollAction/Models/ProjectViewModels/CreateProjectViewModel.cs
@@ -25,7 +25,6 @@ namespace CollAction.Models
         public int CategoryId { get; set; }
 
         [Required(ErrorMessage = "Please specify the target number of collaborators required for your project to be deemed a success")]
-        [DataType(DataType.Text)] // Force this to text rather than .Int to prevent browsers displaying spin buttons (up down arrows) by default.
         [Range(1, 1000000, ErrorMessage = "You can choose up to a maximum of one million participants as your target number")]
         [Display(Prompt = "Target")]
         public int Target { get; set; }


### PR DESCRIPTION
 I do not think the browser arrows are a big enough problem to keep it as a text input. I agree with Alexis that the Target field should be a number/integer field.