### PR TITLE
CA-814 - homepage - time to act - fixed the FAQ link

### DIFF
--- a/Frontend/src/components/Button/Button.tsx
+++ b/Frontend/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from './Button.module.scss';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Link } from 'react-router-dom';
+import { HashLink as Link } from 'react-router-hash-link';
 
 export const Button = ({ children, variant = 'primary', ...props }: any) => {
   // External link


### PR DESCRIPTION
The built in `Link` component of `react-router-dom` does not support hash navigations, so it does not scroll. Since the application already uses `react-router-hash-link`, which exposes `HashLink`, an in place scroll-to-hash-supporting replacement of `Link`, `GhostButton` was changed to use `HashLink`.
This makes the "Read More" link in the Time To Act section in the homepage navigate to the about page and scroll to the FAQ section.

Found by @timstokman.