### PR TITLE
CA-845 - cache preflight requests

### DIFF
--- a/CollAction/Startup.cs
+++ b/CollAction/Startup.cs
@@ -115,6 +115,7 @@ namespace CollAction
                             builder.AllowAnyMethod()
                                    .AllowAnyHeader()
                                    .AllowCredentials()
+                                   .SetPreflightMaxAge(TimeSpan.FromMinutes(10))
                                    .WithOrigins(configuration.Get<SiteOptions>().PublicAddress));
                 }
                 else
@@ -124,6 +125,7 @@ namespace CollAction
                             builder.AllowAnyMethod()
                                    .AllowAnyHeader()
                                    .AllowCredentials()
+                                   .SetPreflightMaxAge(TimeSpan.FromMinutes(10))
                                    .SetIsOriginAllowed(_ => true));
                 }
             });


### PR DESCRIPTION
Will enable performance improvements for graphql requests. 10 minutes is the upper limit for chrome.