### PR TITLE
CA-861 - Fix getCookie so we can get client_id correctly

### DIFF
--- a/Frontend/src/providers/AnalyticsProvider.tsx
+++ b/Frontend/src/providers/AnalyticsProvider.tsx
@@ -23,8 +23,16 @@ const SEND_EVENT = gql`
 
 // Get cookie by name
 const getCookie = (name: string) => {
-    var v = document.cookie.match(`(^|;) ?'${name}'=([^;]*)(;|$)`);
-    return v ? v[2] : null;
+  const found =
+    document.cookie
+            .split('; ')
+            .map(row => row.split('='))
+            .find(row => row[0] === name);
+  if (found) {
+    return found[1];
+  } else {
+    return null;
+  }
 };
 
 // Get local time as ISO string with tz offset at the end.

--- a/Frontend/src/providers/AnalyticsProvider.tsx
+++ b/Frontend/src/providers/AnalyticsProvider.tsx
@@ -28,11 +28,7 @@ const getCookie = (name: string) => {
             .split('; ')
             .map(row => row.split('='))
             .find(row => row[0] === name);
-  if (found) {
-    return found[1];
-  } else {
-    return null;
-  }
+  return found ? found[1] : null;
 };
 
 // Get local time as ISO string with tz offset at the end.


### PR DESCRIPTION
The ga client_id is needed for the analytics