### PR TITLE
CA-868 fix front-end validation

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.0.0-beta.50",
-    "@date-io/moment": "1.x",
     "@fortawesome/fontawesome-svg-core": "^1.2",
     "@fortawesome/free-brands-svg-icons": "^5.12",
     "@fortawesome/free-regular-svg-icons": "^5.12",
@@ -11,9 +10,9 @@
     "@fortawesome/react-fontawesome": "^0.1",
     "@material-ui/core": "^4.9",
     "@material-ui/icons": "^4.9",
-    "@material-ui/pickers": "^3.2.10",
     "@stripe/react-stripe-js": "^1.1",
     "@stripe/stripe-js": "1.5",
+    "date-fns": "^2.16.1",
     "draft-js": "0.11",
     "draft-js-export-html": "^1.4",
     "formik": "^2.1",
@@ -61,7 +60,7 @@
     "typescript": "^3.8"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export REACT_APP_BACKEND_URL=https://localhost:44301 && react-scripts start",
     "build": "react-scripts build",
     "setup-netlify": "envsubst '$REACT_APP_BACKEND_URL' < ../netlify.toml | tee ../netlify.toml",
     "test": "react-scripts test",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -60,7 +60,7 @@
     "typescript": "^3.8"
   },
   "scripts": {
-    "start": "export REACT_APP_BACKEND_URL=https://localhost:44301 && react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "setup-netlify": "envsubst '$REACT_APP_BACKEND_URL' < ../netlify.toml | tee ../netlify.toml",
     "test": "react-scripts test",

--- a/Frontend/src/pages/crowdactions/Create/Create.tsx
+++ b/Frontend/src/pages/crowdactions/Create/Create.tsx
@@ -313,6 +313,13 @@ const CreateCrowdactionPage = () => {
                           Submit crowdaction
                         </Button>
                     }
+                    { !props.isValid &&
+                      <div className={styles.submitErrors}>
+                        <ul>
+                          <li>Not all fields are filled in correctly. Please verify and try again.</li>
+                        </ul>
+                      </div>
+                    }
                     { props.status &&
                       <div className={styles.submitErrors}>
                         <ul>

--- a/Frontend/src/pages/crowdactions/Create/Create.tsx
+++ b/Frontend/src/pages/crowdactions/Create/Create.tsx
@@ -10,42 +10,12 @@ import { Section } from '../../../components/Section/Section';
 import { useUser } from '../../../providers/UserProvider';
 import Categories from './Categories';
 import styles from './Create.module.scss';
-import { initialValues, ICrowdactionForm, validations } from './form';
+import { initialValues, ICrowdactionForm, validations, parseDate } from './form';
 import UploadImage from './UploadImage';
 import { Link, useHistory } from 'react-router-dom';
 import { gql, useMutation } from '@apollo/client';
 import Loader from '../../../components/Loader/Loader';
 import Utils from '../../../utils';
-import {DatePicker, MuiPickersUtilsProvider} from "@material-ui/pickers";
-import MomentUtils from '@date-io/moment';
-
-//https://material-ui-pickers.dev/guides/form-integration
-// @ts-ignore
-const DatePickerField = ({ field, form, ...other }) => {
-  return (
-      <DatePicker
-          clearable
-          disablePast
-          autoOk
-          name={field.name}
-          value={field.value}
-          placeholder={"dd/mm/yyyy"}
-          // helperText={currentError}
-          error={false}
-          variant="inline"
-          format="DD/MM/yyyy"
-          // onError={error => {
-          //   // handle as a side effect
-          //   if (error !== currentError) {
-          //     form.setFieldError(field.name, error);
-          //   }
-          // }}
-          // if you are using custom validation schema you probably want to pass `true` as third argument
-          onChange={date => form.setFieldValue(field.name, date, true)}
-          {...other}
-      />
-  );
-};
 
 const CreateCrowdactionPage = () => {
   const user = useUser();
@@ -108,8 +78,8 @@ const CreateCrowdactionPage = () => {
           target: form.target,
           proposal: form.proposal,
           description: form.description,
-          start: form.startDate,
-          end: form.endDate,
+          start: parseDate(form.startDate),
+          end: parseDate(form.endDate),
           goal: form.goal,
           tags: form.tags ? form.tags.split(';') : [],
           creatorComments: form.comments || null,
@@ -148,7 +118,7 @@ const CreateCrowdactionPage = () => {
   )
 
   const createCrowdactionForm = (
-      <MuiPickersUtilsProvider utils={MomentUtils}>
+    <>
       <Helmet>
         <title>Create a crowdaction</title>
         <meta name="description" content="Create a crowdaction" />
@@ -220,8 +190,9 @@ const CreateCrowdactionPage = () => {
                       name="startDate"
                       label="Launch date"
                       type="text"
+                      placeholder="d/M/yyyy"
                       helperText="Set a date from which people will be able to join the crowdaction"
-                      component={DatePickerField}
+                      component={TextField}
                       className={styles.formRow}
                       fullWidth
                     >
@@ -230,8 +201,9 @@ const CreateCrowdactionPage = () => {
                       name="endDate"
                       label="Sign-up duration"
                       type="text"
+                      placeholder="d/M/yyyy"
                       helperText="Set a specific end date for when the sign-up closes. Sign-up closes on 00:00 GMT on this date"
-                      component={DatePickerField}
+                      component={TextField}
                       className={styles.formRow}
                       fullWidth
                     >
@@ -357,7 +329,7 @@ const CreateCrowdactionPage = () => {
           </Form>
           )}
       </Formik>
-      </MuiPickersUtilsProvider>
+    </>
   );
 
   return user ? createCrowdactionForm : pleaseLogin;

--- a/Frontend/src/pages/crowdactions/Create/Create.tsx
+++ b/Frontend/src/pages/crowdactions/Create/Create.tsx
@@ -190,7 +190,7 @@ const CreateCrowdactionPage = () => {
                       name="startDate"
                       label="Launch date"
                       type="text"
-                      placeholder="d/M/yyyy"
+                      placeholder="dd/mm/yyyy"
                       helperText="Set a date from which people will be able to join the crowdaction"
                       component={TextField}
                       className={styles.formRow}
@@ -201,7 +201,7 @@ const CreateCrowdactionPage = () => {
                       name="endDate"
                       label="Sign-up duration"
                       type="text"
-                      placeholder="d/M/yyyy"
+                      placeholder="dd/mm/yyyy"
                       helperText="Set a specific end date for when the sign-up closes. Sign-up closes on 00:00 GMT on this date"
                       component={TextField}
                       className={styles.formRow}

--- a/Frontend/src/pages/crowdactions/Create/form.ts
+++ b/Frontend/src/pages/crowdactions/Create/form.ts
@@ -77,12 +77,12 @@ export const validations = Yup.object({
     .lessThan(1000001, 'Please choose no more then one million participants'),
   startDate: Yup.date()
     .transform(transformToDate)
-    .required('Please enter a valid launch date, using the format d/M/yyyy')
+    .required('Please enter a valid launch date, using the format dd/mm/yyyy')
     .min(addDays(today, 1), 'Please ensure the launch date starts somewhere in the near future')
     .max(addMonths(today, 12), 'Please ensure the launch date is within the next 12 months'),
   endDate: Yup.date()
     .transform(transformToDate)
-    .required('Please enter a valid end date, using the format d/MM/yyyy')
+    .required('Please enter a valid end date, using the format dd/mm/yyyy')
     .when('startDate', (started: Date, yup: any) => started && yup.min(addDays(started, 1), 'Please ensure your sign up ends after it starts :-)'))
     .when('startDate', (started: Date, yup: any) => started && yup.max(addMonths(started, 12), 'The deadline must be within a year of the start date')),
   tags: Yup.string()

--- a/Frontend/src/pages/crowdactions/Create/form.ts
+++ b/Frontend/src/pages/crowdactions/Create/form.ts
@@ -1,5 +1,5 @@
 import * as Yup from 'yup';
-import { isDate, parse, addDays, startOfDay, addMonths } from 'date-fns';
+import { parse, addDays, startOfDay, addMonths, isDate, isValid } from 'date-fns';
 
 export interface ICrowdactionForm {
   crowdactionName: string;
@@ -50,8 +50,10 @@ const determineImageDescriptionValidation = (image: any, schema: any) => {
 const transformToDate = (value: Date, originalValue: string | Date) => 
   isDate(originalValue) ? originalValue : parseDate(originalValue as string);
 
-export const parseDate = (value: string) =>
-  parse(value, 'd/M/yyyy', new Date());
+export const parseDate = (value: string) => {
+  const date = parse(value, 'd/M/yyyy', new Date());
+  return isValid(date) ? date : undefined;
+}
 
 export const validations = Yup.object({
   crowdactionName: Yup.string()
@@ -74,13 +76,13 @@ export const validations = Yup.object({
     .moreThan(0, 'You can choose up to one million participants')
     .lessThan(1000001, 'Please choose no more then one million participants'),
   startDate: Yup.date()
-    .transform(transformToDate).typeError('Please enter a valid date, using the format d/M/yyyy')
-    .required('Please enter a launch date')
+    .transform(transformToDate)
+    .required('Please enter a valid launch date, using the format d/M/yyyy')
     .min(addDays(today, 1), 'Please ensure the launch date starts somewhere in the near future')
     .max(addMonths(today, 12), 'Please ensure the launch date is within the next 12 months'),
   endDate: Yup.date()
-    .transform(transformToDate).typeError('Please enter a valid date, using the format d/M/yyyy')
-    .required('Please enter an end date')
+    .transform(transformToDate)
+    .required('Please enter a valid end date, using the format d/MM/yyyy')
     .when('startDate', (started: Date, yup: any) => started && yup.min(addDays(started, 1), 'Please ensure your sign up ends after it starts :-)'))
     .when('startDate', (started: Date, yup: any) => started && yup.max(addMonths(started, 12), 'The deadline must be within a year of the start date')),
   tags: Yup.string()

--- a/Frontend/src/pages/crowdactions/Create/form.ts
+++ b/Frontend/src/pages/crowdactions/Create/form.ts
@@ -83,9 +83,9 @@ export const validations = Yup.object({
     .required('Please enter an end date')
     .when('startDate', (started: Date, yup: any) => started && yup.min(addDays(started, 1), 'Please ensure your sign up ends after it starts :-)'))
     .when('startDate', (started: Date, yup: any) => started && yup.max(addMonths(started, 12), 'The deadline must be within a year of the start date')),
-  hashtags: Yup.string()
-    .max(30, 'Please keep the number of hashtags civil, no more then 30 characters')
-    .matches(/^[a-zA-Z_0-9]+(;[a-zA-Z_0-9]+)*$/, 'Don\'t use spaces or #, must contain a letter, can contain digits and underscores. Separate multiple tags with a colon \';\''),
+  tags: Yup.string()
+    .max(300, 'Please keep the number of hashtags civil, no more then 300 characters')
+    .matches(/^([A-Za-z][A-Za-z0-9_-]{0,29})+(;[A-Za-z][A-Za-z0-9_-]{0,29})*$/, 'Tags must be between one and thirty characters, start with a letter, and only contain letters, numbers, underscores or dashes. Seperate tags with a colon \';\''),
   description: Yup.string()
     .required('Give a succinct description of what you are gathering participants for')
     .max(10000, 'Please use no more then 10.000 characters'),

--- a/Frontend/src/pages/crowdactions/Create/form.ts
+++ b/Frontend/src/pages/crowdactions/Create/form.ts
@@ -1,4 +1,5 @@
 import * as Yup from 'yup';
+import { isDate, parse, addDays, startOfDay, addMonths } from 'date-fns';
 
 export interface ICrowdactionForm {
   crowdactionName: string;
@@ -36,6 +37,8 @@ export const initialValues: ICrowdactionForm = {
   youtube: ''
 };
 
+const today = startOfDay(new Date());
+
 const determineImageDescriptionValidation = (image: any, schema: any) => {
   if (!image) {
     return;
@@ -44,9 +47,11 @@ const determineImageDescriptionValidation = (image: any, schema: any) => {
   return schema.required('Please provide a short description for the image');
 }
 
-var minimumDate = new Date();
-var maximumDate = new Date();
-maximumDate.setMonth(minimumDate.getMonth() + 12);
+const transformToDate = (value: Date, originalValue: string | Date) => 
+  isDate(originalValue) ? originalValue : parseDate(originalValue as string);
+
+export const parseDate = (value: string) =>
+  parse(value, 'd/M/yyyy', new Date());
 
 export const validations = Yup.object({
   crowdactionName: Yup.string()
@@ -68,6 +73,16 @@ export const validations = Yup.object({
     .required('Please choose the number of people you want to join')
     .moreThan(0, 'You can choose up to one million participants')
     .lessThan(1000001, 'Please choose no more then one million participants'),
+  startDate: Yup.date()
+    .transform(transformToDate).typeError('Please enter a valid date, using the format d/M/yyyy')
+    .required('Please enter a launch date')
+    .min(addDays(today, 1), 'Please ensure the launch date starts somewhere in the near future')
+    .max(addMonths(today, 12), 'Please ensure the launch date is within the next 12 months'),
+  endDate: Yup.date()
+    .transform(transformToDate).typeError('Please enter a valid date, using the format d/M/yyyy')
+    .required('Please enter an end date')
+    .when('startDate', (started: Date, yup: any) => started && yup.min(addDays(started, 1), 'Please ensure your sign up ends after it starts :-)'))
+    .when('startDate', (started: Date, yup: any) => started && yup.max(addMonths(started, 12), 'The deadline must be within a year of the start date')),
   hashtags: Yup.string()
     .max(30, 'Please keep the number of hashtags civil, no more then 30 characters')
     .matches(/^[a-zA-Z_0-9]+(;[a-zA-Z_0-9]+)*$/, 'Don\'t use spaces or #, must contain a letter, can contain digits and underscores. Separate multiple tags with a colon \';\''),

--- a/Frontend/yarn.lock
+++ b/Frontend/yarn.lock
@@ -1091,13 +1091,6 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.6.0":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@^7.10.1", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.1.tgz#e167154a94cb5f14b28dc58f5356d2162f539811"
@@ -1148,18 +1141,6 @@
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
-
-"@date-io/core@1.x", "@date-io/core@^1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
-  integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
-
-"@date-io/moment@1.x":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.13.tgz#56c2772bc4f6675fc6970257e6033e7a7c2960f0"
-  integrity sha512-3kJYusJtQuOIxq6byZlzAHoW/18iExJer9qfRF5DyyzdAk074seTuJfdofjz4RFfTd/Idk8WylOQpWtERqvFuQ==
-  dependencies:
-    "@date-io/core" "^1.3.13"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -1420,18 +1401,6 @@
   integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
   dependencies:
     "@babel/runtime" "^7.4.4"
-
-"@material-ui/pickers@^3.2.10":
-  version "3.2.10"
-  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.2.10.tgz#19df024895876eb0ec7cd239bbaea595f703f0ae"
-  integrity sha512-B8G6Obn5S3RCl7hwahkQj9sKUapwXWFjiaz/Bsw1fhYFdNMnDUolRiWQSoKPb1/oKe37Dtfszoywi1Ynbo3y8w==
-  dependencies:
-    "@babel/runtime" "^7.6.0"
-    "@date-io/core" "1.x"
-    "@types/styled-jsx" "^2.2.8"
-    clsx "^1.0.2"
-    react-transition-group "^4.0.0"
-    rifm "^0.7.0"
 
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
@@ -1859,13 +1828,6 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
-"@types/styled-jsx@^2.2.8":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@types/styled-jsx/-/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
-  integrity sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==
-  dependencies:
-    "@types/react" "*"
 
 "@types/testing-library__dom@*":
   version "7.0.2"
@@ -3328,7 +3290,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.0.2, clsx@^1.0.4:
+clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -3961,6 +3923,11 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
+
+date-fns@^2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
 debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
@@ -9876,7 +9843,7 @@ react-slick@^0.26:
     lodash.debounce "^4.0.8"
     resize-observer-polyfill "^1.5.0"
 
-react-transition-group@^4.0.0, react-transition-group@^4.4.0:
+react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
@@ -10306,13 +10273,6 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
-
-rifm@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.7.0.tgz#debe951a9c83549ca6b33e5919f716044c2230be"
-  integrity sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
 
 rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "Frontend/"
-  publish = "build/"
+  publish = "Frontend/build/"
   command = "yarn run setup-netlify && yarn run build"
 
 [build.environment]


### PR DESCRIPTION
Simplified date entry on project creation form. Dates must now always be entered (with plain text input) as d/M/yyyy. At least it will work in every browser, no matter what localisation settings.

This also makes entry easier then de UI date-selector, and I readded the client-side validation so user get validation feedback on the dates before project is submitted.